### PR TITLE
Add custom types for type hinting

### DIFF
--- a/character_gui/__init__.py
+++ b/character_gui/__init__.py
@@ -1,0 +1,1 @@
+from character_gui import character_generator, extra_types

--- a/character_gui/character_generator.py
+++ b/character_gui/character_generator.py
@@ -10,9 +10,14 @@ import os
 import sys
 import subprocess
 
+from character_gui.extra_types import *
+
 
 class CharacterGenerator:
-    def __init__(self, character, create_mode, extend_character) -> None:
+    def __init__(self,
+                 character: CharacterDataType,
+                 create_mode: bool,
+                 extend_character: dict[str, bool]) -> None:
         self._imported_character = character
         self._extend_character = extend_character
         self._current_character = deepcopy(self._imported_character)
@@ -37,7 +42,7 @@ class CharacterGenerator:
 
         self._section_title_color = [150, 250, 150]
 
-        self._stats = {
+        self._stats: dict[str, ValueType] = {
             "Carry Capacity": {
                 "value": 55,
                 "tooltip": "Affected by Strength and various Traits.",
@@ -86,7 +91,7 @@ class CharacterGenerator:
             )
         )
 
-    def _serialize_properties(self, character):
+    def _serialize_properties(self, character: dict):
         properties = dict()
         for key, value in character.items():
             if "value" in character[key]:
@@ -105,7 +110,7 @@ class CharacterGenerator:
         return self._imported_character["Config"]["Starting Traits"]
 
     @staticmethod
-    def _get_total_knowledge_cost(skills: dict, default_cost: list) -> int:
+    def _get_total_knowledge_cost(skills: SkillsType, default_cost: list[int]) -> int:
         """
         Calulate the xp cost for either all skills.
         """
@@ -121,9 +126,8 @@ class CharacterGenerator:
 
     def _get_total_attribute_cost(self) -> int:
         sum_points = 0
-        for attribute in self._current_character["Character"]["Attributes"]["All"][
-            "Attribute"
-        ].values():
+        attribute: AttributeType
+        for attribute in self._current_character["Character"]["Attributes"]["All"]["Attribute"].values():
             sum_points = sum_points + attribute["value"]
         return sum_points
 
@@ -151,7 +155,7 @@ class CharacterGenerator:
         return sum_traits
 
     @staticmethod
-    def _get_total_property_cost(properties: dict) -> int:
+    def _get_total_property_cost(properties: TraitsType | ExpertisesType) -> int:
         """
         Calculate the total cost from boolean poperties .
         For example 'Advantages'.
@@ -166,7 +170,7 @@ class CharacterGenerator:
                             sum_cost = sum_cost + property["cost"]
         return sum_cost
 
-    def _get_allowed_min_value(self, item: dict) -> int:
+    def _get_allowed_min_value(self, item: MinMaxType) -> int:
         min = item["value"]
         if self._create_mode:
             min = item["min"]
@@ -339,9 +343,7 @@ class CharacterGenerator:
         Must be called whenever a related value have been change.
         """
 
-        psycho_limit = self._current_character["Character"]["Attributes"]["All"][
-            "Attribute"
-        ]["Psyche"]["value"]
+        psycho_limit: int = self._current_character["Character"]["Attributes"]["All"]["Attribute"]["Psyche"]["value"]
         self._stats["Psycho Limit"]["value"] = psycho_limit
         dpg.set_value(
             item="Psycho Limit",
@@ -354,10 +356,8 @@ class CharacterGenerator:
         Must be called whenever a related value have been change.
         """
 
-        stress_limit = (
-            self._current_character["Character"]["Attributes"]["All"]["Attribute"][
-                "Psyche"
-            ]["value"]
+        stress_limit: int = (
+            self._current_character["Character"]["Attributes"]["All"]["Attribute"]["Psyche"]["value"]
             + 1
         )
         bonus_string = "".join(self._check_active_bonuses("Stress Limit"))
@@ -373,9 +373,7 @@ class CharacterGenerator:
         Must be called whenever a related value have been change.
         """
 
-        stunt_cap = self._current_character["Character"]["Attributes"]["All"][
-            "Attribute"
-        ]["Charisma"]["value"]
+        stunt_cap: int = self._current_character["Character"]["Attributes"]["All"]["Attribute"]["Charisma"]["value"]
         self._stats["Stunt Cap"]["value"] = stunt_cap
         dpg.set_value(
             item="Stunt Cap",
@@ -388,10 +386,8 @@ class CharacterGenerator:
         Must be called whenever a related value have been change.
         """
 
-        health = (
-            self._current_character["Character"]["Attributes"]["All"]["Attribute"][
-                "Endurance"
-            ]["value"]
+        health: int = (
+            self._current_character["Character"]["Attributes"]["All"]["Attribute"]["Endurance"]["value"]
             + 3
         )
         self._stats["Health"]["value"] = health
@@ -405,10 +401,8 @@ class CharacterGenerator:
         Update the printout of current carry capacity.
         Must be called whenever a related value have been change.
         """
-        carry_capacity = self._current_character["Config"]["Carry Capacity Table"][
-            self._current_character["Character"]["Attributes"]["All"]["Attribute"][
-                "Strength"
-            ]["value"]
+        carry_capacity: int = self._current_character["Config"]["Carry Capacity Table"][
+            self._current_character["Character"]["Attributes"]["All"]["Attribute"]["Strength"]["value"]
             - 1
         ]
         self._stats["Carry Capacity"]["value"] = carry_capacity
@@ -423,9 +417,7 @@ class CharacterGenerator:
         Must be called whenever a related value have been change.
         """
         combat_load = self._current_character["Config"]["Combat Load Table"][
-            self._current_character["Character"]["Attributes"]["All"]["Attribute"][
-                "Strength"
-            ]["value"]
+            self._current_character["Character"]["Attributes"]["All"]["Attribute"]["Strength"]["value"]
             - 1
         ]
         self._stats["Combat Load"]["value"] = combat_load
@@ -440,11 +432,9 @@ class CharacterGenerator:
         Must be called whenever a related value have been change.
         """
         rank_index = self._current_character["Player Info"]["Rank"]
-        leadership_points = (
+        leadership_points: int = (
             self._current_character["Config"]["Rank Bonus"][rank_index]
-            + self._current_character["Character"]["Attributes"]["All"]["Attribute"][
-                "Charisma"
-            ]["value"]
+            + self._current_character["Character"]["Attributes"]["All"]["Attribute"]["Charisma"]["value"]
         )
         self._stats["Leadership Points"]["value"] = leadership_points
         dpg.set_value(
@@ -480,10 +470,10 @@ class CharacterGenerator:
         dpg.set_value(item="Available Traits", value=remaining)
 
     def _update_overview(self):
-        overview_list = ""
+        overview_list: str = ""
         for property_key, property_value in self._serial_properties.items():
             if "cost" in property_value and property_value["value"]:
-                cost = property_value["cost"]
+                cost: int = property_value["cost"]
                 overview_list = overview_list + f"{property_key} ({cost})\n"
         dpg.set_value("overview_list", overview_list)
 
@@ -513,7 +503,7 @@ class CharacterGenerator:
             subprocess.call(["xdg-open", file_path])
 
     @staticmethod
-    def _split_dict(source, num_per_part, max_row_count=24):
+    def _split_dict(source: dict, num_per_part: int, max_row_count=24):
         """
         Helper function to dived a set of components into groups
         in order to control the number of items shown horisontally.
@@ -521,10 +511,10 @@ class CharacterGenerator:
         * Limit the amount traits/advantages/disadvantages for each column.
         " Limit the amount of skill sub categories for each column.
         """
-        split_items = []
+        split_items: list[dict] = []
         part = dict()
-        row_count = 0
-        category_count = 0
+        row_count: int = 0
+        category_count: int = 0
         for item_key, item_value in source.items():
             part[item_key] = item_value
             category_count = category_count + 1
@@ -945,14 +935,14 @@ class CharacterSelector:
     def __init__(self):
         self._section_title_color = [150, 250, 150]
 
-        self._available_characters = []
+        self._available_characters: list[str] = []
 
         """
         When true, the character i fully editable in the same way as creating a new character.
         When False, XP can only be spend, not removed.
         This feature will be remove/hidden in the final version.
         """
-        self._create_mode = False
+        self._create_mode: bool = False
 
         self._extend_character = {"military": True, "navy": True, "colonist": True}
 
@@ -1109,13 +1099,13 @@ class CharacterImport:
     Handle import of character. Currenty only from json-file.
     """
 
-    def __init__(self, character):
+    def __init__(self, character: CharacterDataType):
         self._character = character
 
     @classmethod
-    def from_json(cls, character_path):
+    def from_json(cls, character_path: str | os.PathLike):
         with open(character_path) as setup_file:
-            imported_character = json.load(setup_file)
+            imported_character: CharacterDataType = json.load(setup_file)
 
         return cls(imported_character)
 
@@ -1128,12 +1118,14 @@ class CharacterExport:
     Handle import of character. Currenty only from json-file.
     """
 
-    def __init__(self, character_path, character):
+    def __init__(self, character_path: str | os.PathLike,
+                 character: CharacterDataType):
         self._character = deepcopy(character)
         self._character_path = character_path
 
     @classmethod
-    def to_json(cls, character_path, character):
+    def to_json(cls, character_path: str | os.PathLike,
+                 character: CharacterDataType):
         character_out = deepcopy(character)
         # Convert from true/false to 1/0
         for tab_label in character_out["Character"]:
@@ -1158,7 +1150,9 @@ class CharacterExport:
 
 
 class CharacterToPdf:
-    def __init__(self, character, stats, out_file):
+    def __init__(self, character: CharacterDataType,
+                 stats: dict[str, ValueType],
+                 out_file):
         self._line_height = 15
         self._current_y = 820
         self._current_x = 20
@@ -1168,7 +1162,7 @@ class CharacterToPdf:
         self.out_file = out_file
         self._canvas = canvas.Canvas(self.out_file, pagesize=(595, 842))
 
-    def _write_line(self, line, title=False):
+    def _write_line(self, line: str, title=False):
         if title:
             self._canvas.setFont("Helvetica-Bold", self._font_size)
         else:
@@ -1204,9 +1198,7 @@ class CharacterToPdf:
         self._write_line(" ")
 
         self._write_line("Attributes", title=True)
-        for attribute, content in self._character["Character"]["Attributes"]["All"][
-            "Attribute"
-        ].items():
+        for attribute, content in self._character["Character"]["Attributes"]["All"]["Attribute"].items():
             value = content["value"]
             self._write_line(f"{attribute}: {value}")
 

--- a/character_gui/character_generator.py
+++ b/character_gui/character_generator.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from reportlab.pdfgen import canvas
 
 import glob
+from pathlib import Path
 import os
 import sys
 import subprocess
@@ -1102,7 +1103,7 @@ class CharacterImport:
         self._character = character
 
     @classmethod
-    def from_json(cls, character_path: str | os.PathLike):
+    def from_json(cls, character_path: Path):
         with open(character_path) as setup_file:
             imported_character: CharacterDataType = json.load(setup_file)
 
@@ -1117,13 +1118,13 @@ class CharacterExport:
     Handle import of character. Currenty only from json-file.
     """
 
-    def __init__(self, character_path: str | os.PathLike,
+    def __init__(self, character_path: Path,
                  character: CharacterDataType):
         self._character = deepcopy(character)
         self._character_path = character_path
 
     @classmethod
-    def to_json(cls, character_path: str | os.PathLike,
+    def to_json(cls, character_path: Path,
                  character: CharacterDataType):
         character_out = deepcopy(character)
         # Convert from true/false to 1/0

--- a/character_gui/character_generator.py
+++ b/character_gui/character_generator.py
@@ -10,7 +10,7 @@ import os
 import sys
 import subprocess
 
-from character_gui.extra_types import *
+from extra_types import *
 
 
 class CharacterGenerator:
@@ -110,7 +110,7 @@ class CharacterGenerator:
         return self._imported_character["Config"]["Starting Traits"]
 
     @staticmethod
-    def _get_total_knowledge_cost(skills: SkillsType, default_cost: list[int]) -> int:
+    def _get_total_knowledge_cost(skills: SkillGroupType, default_cost: list[int]) -> int:
         """
         Calulate the xp cost for either all skills.
         """
@@ -126,7 +126,6 @@ class CharacterGenerator:
 
     def _get_total_attribute_cost(self) -> int:
         sum_points = 0
-        attribute: AttributeType
         for attribute in self._current_character["Character"]["Attributes"]["All"]["Attribute"].values():
             sum_points = sum_points + attribute["value"]
         return sum_points
@@ -204,7 +203,7 @@ class CharacterGenerator:
         self._update_combat_load()
         self._check_property_disable()
 
-    def _get_value_from_character_state(self, property_data: dict) -> int:
+    def _get_value_from_character_state(self, property_data: dict[str, str]) -> int:
         """
         Helper function to get a specific value.
         """

--- a/character_gui/extra_types.py
+++ b/character_gui/extra_types.py
@@ -1,0 +1,77 @@
+from typing import NotRequired, TypedDict
+
+class ValueType(TypedDict):
+    value: int
+    tooltip: NotRequired[str]
+    extended: NotRequired[str]
+
+class MinMaxType(TypedDict):
+    max: int
+    min: int
+
+class CostType(TypedDict):
+    cost: int
+
+class RequirementType(TypedDict):
+    type: str
+    value: int
+
+class RequirementsType(TypedDict, total=False):
+    requirements: dict[str, RequirementType]
+
+class AttributeType(ValueType, MinMaxType):
+    pass
+type AttributesType = dict[str, AttributeType]
+
+class SkillType(ValueType, MinMaxType):
+    pass
+type SkillGroupType = dict[str, SkillType]
+type SkillsType = dict[str, SkillGroupType]
+
+class TraitType(ValueType, CostType, RequirementsType):
+    pass
+type TraitSubtabType = dict[str, TraitType]
+type TraitGroupType = dict[str, TraitSubtabType]
+type TraitsType = dict[str, TraitGroupType]
+
+class ExpertiseType(ValueType, CostType):
+    pass
+type ExpertiseSubcategoryType = dict[str, ExpertiseType]
+type ExpertiseCategoryType = dict[str, ExpertiseSubcategoryType]
+type ExpertisesType = dict[str, ExpertiseCategoryType]
+
+class PlayerInfoType(TypedDict):
+    Player: str
+    Email: str
+    Name: str
+    Platoon: str
+    Rank: int
+    Speciality: str
+    Gender: str
+    Age: str
+
+class CharacterConfigType(TypedDict):
+    StartingXP: int
+    StartingAP: int
+    StartingTraits: int
+    Specialities: list[str]
+    Platoons: list[str]
+    Genders: list[str]
+    SkillCostTable: list[int]
+    Age: dict[str, int]
+    RankLabels: list[str]
+    RankBonus: list[int]
+    CarryCapacityTable: list[int]
+    CombatLoadTable: list[int]
+    
+class CharacterPropertiesType(TypedDict):
+    Attributes: AttributesType
+    Skills: SkillsType
+    Traits: TraitsType
+    Expertise: ExpertisesType
+
+class CharacterDataType(TypedDict):
+    PlayerInfo: PlayerInfoType
+    Config: CharacterConfigType
+    Character: CharacterPropertiesType
+       

--- a/character_gui/extra_types.py
+++ b/character_gui/extra_types.py
@@ -4,12 +4,13 @@ class ValueType(TypedDict):
     value: int
     tooltip: NotRequired[str]
     extended: NotRequired[str]
+    cost_table: NotRequired[list[int]]
 
-class MinMaxType(TypedDict):
+class MinMaxType(ValueType):
     max: int
     min: int
 
-class CostType(TypedDict):
+class CostType(ValueType):
     cost: int
 
 class RequirementType(TypedDict):
@@ -19,22 +20,23 @@ class RequirementType(TypedDict):
 class RequirementsType(TypedDict, total=False):
     requirements: dict[str, RequirementType]
 
-class AttributeType(ValueType, MinMaxType):
+class AttributeType(MinMaxType):
     pass
-type AttributesType = dict[str, AttributeType]
+type AttributeGroupType = dict[str, AttributeType]
+type AttributesType = dict[str, AttributeGroupType]
 
-class SkillType(ValueType, MinMaxType):
+class SkillType(MinMaxType):
     pass
 type SkillGroupType = dict[str, SkillType]
 type SkillsType = dict[str, SkillGroupType]
 
-class TraitType(ValueType, CostType, RequirementsType):
+class TraitType(CostType, RequirementsType):
     pass
-type TraitSubtabType = dict[str, TraitType]
-type TraitGroupType = dict[str, TraitSubtabType]
+type TraitSubgroupType = dict[str, TraitType]
+type TraitGroupType = dict[str, TraitSubgroupType]
 type TraitsType = dict[str, TraitGroupType]
 
-class ExpertiseType(ValueType, CostType):
+class ExpertiseType(CostType):
     pass
 type ExpertiseSubcategoryType = dict[str, ExpertiseType]
 type ExpertiseCategoryType = dict[str, ExpertiseSubcategoryType]

--- a/character_gui/extra_types.py
+++ b/character_gui/extra_types.py
@@ -22,12 +22,14 @@ class RequirementsType(TypedDict, total=False):
 
 class AttributeType(MinMaxType):
     pass
-type AttributeGroupType = dict[str, AttributeType]
+type AttributeSubgroupType = dict[str, AttributeType]
+type AttributeGroupType = dict[str, AttributeSubgroupType]
 type AttributesType = dict[str, AttributeGroupType]
 
 class SkillType(MinMaxType):
     pass
-type SkillGroupType = dict[str, SkillType]
+type SkillSubGroupType = dict[str, SkillType]
+type SkillGroupType = dict[str, SkillSubGroupType]
 type SkillsType = dict[str, SkillGroupType]
 
 class TraitType(CostType, RequirementsType):

--- a/character_gui/extra_types.py
+++ b/character_gui/extra_types.py
@@ -40,29 +40,35 @@ type ExpertiseSubcategoryType = dict[str, ExpertiseType]
 type ExpertiseCategoryType = dict[str, ExpertiseSubcategoryType]
 type ExpertisesType = dict[str, ExpertiseCategoryType]
 
-class PlayerInfoType(TypedDict):
-    Player: str
-    Email: str
-    Name: str
-    Platoon: str
-    Rank: int
-    Speciality: str
-    Gender: str
-    Age: str
+PlayerInfoType = TypedDict("PlayerInfoType",
+    {
+        "Player": str,
+        "E-mail": str,
+        "Name": str,
+        "Platoon": str,
+        "Rank": int,
+        "Speciality": str,
+        "Gender": str,
+        "Age": int
+    }
+)
 
-class CharacterConfigType(TypedDict):
-    StartingXP: int
-    StartingAP: int
-    StartingTraits: int
-    Specialities: list[str]
-    Platoons: list[str]
-    Genders: list[str]
-    SkillCostTable: list[int]
-    Age: dict[str, int]
-    RankLabels: list[str]
-    RankBonus: list[int]
-    CarryCapacityTable: list[int]
-    CombatLoadTable: list[int]
+CharacterConfigType = TypedDict("CharacterConfigType",
+    {
+        "Starting XP": int,
+        "Starting AP": int,
+        "Starting Traits": int,
+        "specialities": list[str],
+        "platoons": list[str],
+        "genders": list[str],
+        "skill_cost_table": list[int],
+        "age": dict[str, int],
+        "Rank Labels": list[str],
+        "Rank Bonus": list[int],
+        "Carry Capacity Table": list[int],
+        "Combat Load Table": list[int]
+    }
+)
     
 class CharacterPropertiesType(TypedDict):
     Attributes: AttributesType
@@ -70,8 +76,10 @@ class CharacterPropertiesType(TypedDict):
     Traits: TraitsType
     Expertise: ExpertisesType
 
-class CharacterDataType(TypedDict):
-    PlayerInfo: PlayerInfoType
-    Config: CharacterConfigType
-    Character: CharacterPropertiesType
-       
+CharacterDataType = TypedDict("CharacterDataType",
+    {
+        "Player Info": PlayerInfoType,
+        "Config": CharacterConfigType,
+        "Character": CharacterPropertiesType,
+    }
+)


### PR DESCRIPTION
Non-functional change which adds custom types for type hinting. This simplifies understanding of the code for any future updates, given the deep nesting of dicts that exists in some cases.